### PR TITLE
code flow fixes

### DIFF
--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowAuthenticationHelper.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowAuthenticationHelper.java
@@ -88,11 +88,11 @@ class CodeFlowAuthenticationHelper
 
         if (uriAddress.equals(redirectUri))
         {
-            // authentication done!
-            engine.load(_authenticationDoneUrl);
-
             Platform.runLater(() ->
             {
+                // authentication done!
+                engine.load(_authenticationDoneUrl);
+
                 browser.getBackButton().setDisable(true);
                 browser.getNextButton().setDisable(true);
                 onAuthenticationDone.run();

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowController.java
@@ -217,12 +217,14 @@ public class CodeFlowController
 
     private Either<URI, String> validateRedirect(Response response)
     {
-        if (response.getStatus() != 302)
+        int status = response.getStatus();
+
+        if (status < 300 || status >= 400)
         {
             return Either.failure(String.format(
-                    "The OAuth server was expected to return a 302 status code for the code flow authorize request," +
-                            " but it returned %d instead. Check the server response to see what went wrong.",
-                    response.getStatus()));
+                    "The OAuth server was expected to return a status code in the range of 300 to 399 for the code " +
+                            "flow authorize request, but it returned %d instead. Check the server response to see what " +
+                            "went wrong.", status));
         }
 
         List<Object> locationHeaders = response.getHeaders().get("Location");
@@ -251,12 +253,14 @@ public class CodeFlowController
     @Nullable
     private String checkAuthorizeRequestResponse(CodeFlowAuthorizeRequest request, Response response)
     {
-        if (response.getStatus() != 302)
+        int status = response.getStatus();
+
+        if (status < 300 || status >= 400)
         {
             return String.format(
-                    "The OAuth server was expected to return a 302 status code for the code flow authorize request," +
-                            " but it returned %d instead. Check the server response to see what went wrong.",
-                    response.getStatus());
+                    "The OAuth server was expected to return a status code in the range of 300 to 399 for the code " +
+                            "flow authorize request, but it returned %d instead. Check the server response to see " +
+                            "what went wrong.", status);
         }
 
         List<Object> locationHeaders = response.getHeaders().get("Location");

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowController.java
@@ -186,7 +186,9 @@ public class CodeFlowController
         {
             if (_oauthServerState != null)
             {
-                _authenticationHelper.authenticate(uri, curlCommand.getScene().getWindow(), _oauthServerState)
+                String redirectUri = request.getState().getRedirectUri();
+
+                _authenticationHelper.authenticate(uri, curlCommand.getScene().getWindow(), redirectUri)
                         .onSuccess((nextUri) ->
                         {
                             HttpRequest afterAuthnRequest = new CodeFlowAfterAuthenticationRequest(nextUri);

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/flows/code/CodeFlowController.java
@@ -352,17 +352,17 @@ public class CodeFlowController
         if (!cookieStore.getCookies().isEmpty())
         {
 
-            ButtonType yesButton = new ButtonType("Yes", ButtonBar.ButtonData.OK_DONE);
-            ButtonType noButton = new ButtonType("No", ButtonBar.ButtonData.CANCEL_CLOSE);
+            ButtonType yesButton = new ButtonType("Delete Cookies", ButtonBar.ButtonData.OK_DONE);
+            ButtonType noButton = new ButtonType("Proceed", ButtonBar.ButtonData.CANCEL_CLOSE);
 
             String content = "When your session already contains cookies, it is possible that you have " +
-                    "authenticated before because authenticators may remember you by setting cookies.\n" +
-                    "If you go back to the authenticator page with valid authentication cookies, the authenticator " +
-                    "will just send you back to your application without bothering you again with credentials " +
-                    "checking. In normal circumstances, that's great, but if you want to test the authenticator, " +
+                    "authenticated before because your authentication service may remember you by setting a cookie.\n" +
+                    "If you go back to that service with a valid authentication cookie, the authentication service " +
+                    "will just redirect you back to the OAuth server without bothering you again with credential " +
+                    "checking. In normal circumstances, this is great. If, however, you want to re-test authentication, " +
                     "that's not what you want.\n\n" +
                     "To forget your cookies from a previous session and force authentication to happen again, " +
-                    "choose 'Yes', otherwise, choose 'No'.";
+                    "choose 'Delete Cookies', otherwise, choose 'Proceed'.";
 
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION, content, yesButton, noButton);
 

--- a/oauthtest-core/src/main/resources/html/browser/authentication-done.html
+++ b/oauthtest-core/src/main/resources/html/browser/authentication-done.html
@@ -1,4 +1,11 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
 <html>
+<head>
+    <title>Authorization Server Callback Complete</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body>
 <h1>Congratulations</h1>
 <div>
     <p>The Authorization server redirected you back to the OAuth server!</p>
@@ -7,4 +14,5 @@
         <a href="https://tools.ietf.org/html/rfc6749#section-4.1.2">Step 2</a> of the OAuth Code Flow.</p>
     <p><em>Close this window to proceed!</em></p>
 </div>
+</body>
 </html>


### PR DESCRIPTION
This PR fixes a few little things from PR #35:

- Wait for the loading of the client's `redirect_uri` to signal completion of the flow that should take place in the browser.
- The final HTML doc is now valid; I thought my JVM was crashing because it wasn't. That wasn't the problem, but oh, well. Nice to say it's *valid* now :+1: 
- Clarified some of the wording around the existence of cookies when re-authenticating
- Loads the final HTML doc in a call to `Platform.runLater` which is ultimately what fixed the JVM crash I was experiencing.