### PR TITLE
Feature/master/wp 42 save authz code flow prefs

### DIFF
--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/GeneralSettingsController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/GeneralSettingsController.java
@@ -22,21 +22,10 @@ public class GeneralSettingsController
     private final EventBus _eventBus;
     private final UserPreferences _userPreferences;
 
-    public GeneralSettingsController(EventBus eventBus, Stage primaryStage, UserPreferences userPreferences)
+    public GeneralSettingsController(EventBus eventBus, UserPreferences userPreferences)
     {
         _eventBus = eventBus;
         _userPreferences = userPreferences;
-        EventHandler<WindowEvent> onCloseRequest = primaryStage.getOnCloseRequest();
-
-        primaryStage.setOnCloseRequest(e ->
-        {
-            _userPreferences.putGeneralPreferences(getGeneralState());
-
-            if (onCloseRequest != null)
-            {
-                onCloseRequest.handle(e);
-            }
-        });
     }
 
     @FXML

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/GeneralSettingsController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/GeneralSettingsController.java
@@ -1,10 +1,12 @@
 package se.curity.oauth.core.controller;
 
 import javafx.beans.InvalidationListener;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 import se.curity.oauth.core.state.GeneralState;
 import se.curity.oauth.core.util.UserPreferences;
 import se.curity.oauth.core.util.Validators;
@@ -24,10 +26,16 @@ public class GeneralSettingsController
     {
         _eventBus = eventBus;
         _userPreferences = userPreferences;
+        EventHandler<WindowEvent> onCloseRequest = primaryStage.getOnCloseRequest();
 
         primaryStage.setOnCloseRequest(e ->
         {
-            _userPreferences.putGeneralSettings(getGeneralState());
+            _userPreferences.putGeneralPreferences(getGeneralState());
+
+            if (onCloseRequest != null)
+            {
+                onCloseRequest.handle(e);
+            }
         });
     }
 

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/OAuthServerController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/OAuthServerController.java
@@ -1,9 +1,11 @@
 package se.curity.oauth.core.controller;
 
 import javafx.beans.InvalidationListener;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
 import se.curity.oauth.core.state.OAuthServerState;
 import se.curity.oauth.core.util.UserPreferences;
 import se.curity.oauth.core.util.Validators;
@@ -33,8 +35,17 @@ public class OAuthServerController
         _eventBus = eventBus;
         _userPreferences = userPreferences;
 
+        EventHandler<WindowEvent> onCloseRequest = primaryStage.getOnCloseRequest();
+
         primaryStage.setOnCloseRequest(e ->
-                _userPreferences.putOAuthServerPreferences(getOAuthServerState()));
+        {
+            _userPreferences.putOAuthServerPreferences(getOAuthServerState());
+
+            if (onCloseRequest != null)
+            {
+                onCloseRequest.handle(e);
+            }
+        });
     }
 
     @FXML

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/OAuthServerController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/OAuthServerController.java
@@ -28,24 +28,10 @@ public class OAuthServerController
     private final EventBus _eventBus;
     private final UserPreferences _userPreferences;
 
-    public OAuthServerController(EventBus eventBus,
-                                 Stage primaryStage,
-                                 UserPreferences userPreferences)
+    public OAuthServerController(EventBus eventBus, UserPreferences userPreferences)
     {
         _eventBus = eventBus;
         _userPreferences = userPreferences;
-
-        EventHandler<WindowEvent> onCloseRequest = primaryStage.getOnCloseRequest();
-
-        primaryStage.setOnCloseRequest(e ->
-        {
-            _userPreferences.putOAuthServerPreferences(getOAuthServerState());
-
-            if (onCloseRequest != null)
-            {
-                onCloseRequest.handle(e);
-            }
-        });
     }
 
     @FXML

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/SslSettingsController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/SslSettingsController.java
@@ -1,10 +1,12 @@
 package se.curity.oauth.core.controller;
 
 import javafx.beans.InvalidationListener;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 import javafx.scene.control.ToggleGroup;
+import javafx.stage.WindowEvent;
 import se.curity.oauth.core.state.SslState;
 import se.curity.oauth.core.util.UserPreferences;
 import se.curity.oauth.core.util.event.EventBus;
@@ -33,10 +35,16 @@ public class SslSettingsController
     {
         _eventBus = eventBus;
         _userPreferences = userPreferences;
+        EventHandler<WindowEvent> onCloseRequest = primaryStage.getOnCloseRequest();
 
         primaryStage.setOnCloseRequest(e ->
         {
-            _userPreferences.putSslState(getSslState());
+            _userPreferences.putSslPreferences(getSslState());
+
+            if (onCloseRequest != null)
+            {
+                onCloseRequest.handle(e);
+            }
         });
     }
 

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/controller/SslSettingsController.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/controller/SslSettingsController.java
@@ -31,21 +31,10 @@ public class SslSettingsController
     private final EventBus _eventBus;
     private final UserPreferences _userPreferences;
 
-    public SslSettingsController(EventBus eventBus, Stage primaryStage, UserPreferences userPreferences)
+    public SslSettingsController(EventBus eventBus, UserPreferences userPreferences)
     {
         _eventBus = eventBus;
         _userPreferences = userPreferences;
-        EventHandler<WindowEvent> onCloseRequest = primaryStage.getOnCloseRequest();
-
-        primaryStage.setOnCloseRequest(e ->
-        {
-            _userPreferences.putSslPreferences(getSslState());
-
-            if (onCloseRequest != null)
-            {
-                onCloseRequest.handle(e);
-            }
-        });
     }
 
     @FXML

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/state/CodeFlowAuthzState.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/state/CodeFlowAuthzState.java
@@ -1,11 +1,12 @@
 package se.curity.oauth.core.state;
 
 import se.curity.oauth.core.util.Validatable;
+import se.curity.oauth.core.util.event.Event;
 
 import java.util.Collections;
 import java.util.List;
 
-public class CodeFlowAuthzState extends Validatable
+public class CodeFlowAuthzState extends Validatable implements Event
 {
 
     private final String responseType;

--- a/oauthtest-core/src/main/java/se/curity/oauth/core/util/UserPreferences.java
+++ b/oauthtest-core/src/main/java/se/curity/oauth/core/util/UserPreferences.java
@@ -1,6 +1,7 @@
 package se.curity.oauth.core.util;
 
 import se.curity.oauth.core.MainApplication;
+import se.curity.oauth.core.state.CodeFlowAuthzState;
 import se.curity.oauth.core.state.GeneralState;
 import se.curity.oauth.core.state.OAuthServerState;
 import se.curity.oauth.core.state.SslState;
@@ -11,6 +12,12 @@ import static se.curity.oauth.core.state.SslState.SslOption.TRUST_OAUTH_SERVER_C
 
 public final class UserPreferences
 {
+    private static final String CODE_FLOW_RESPONSE_TYPE_PREFERENCE_KEY = "CODE_FLOW_RESPONSE_TYPE_PREFERENCE_KEY";
+    private static final String CODE_FLOW_CLIENT_ID_PREFERENCE_KEY = "CODE_FLOW_CLIENT_ID_PREFERENCE_KEY";
+    private static final String CODE_FLOW_REDIRECT_URI_PREFERENCE_KEY = "CODE_FLOW_REDIRECT_URI_PREFERENCE_KEY";
+    private static final String CODE_FLOW_SCOPE_PREFERENCE_KEY = "CODE_FLOW_SCOPE_PREFERENCE_KEY";
+    private static final String CODE_FLOW_STATE_PREFERENCE_KEY = "CODE_FLOW_STATE_PREFERENCE_KEY";
+
     private final Preferences _preferences = Preferences.userNodeForPackage(MainApplication.class);
     private static final String BASE_URL_PREFERENCE_KEY = "BASE_URL";
 
@@ -27,6 +34,26 @@ public final class UserPreferences
     private static final String TRUSTSTORE_PASSWORD = "TRUSTSTORE_PASSWORD";
     private static final String KEYSTORE_FILE = "KEYSTORE_FILE";
     private static final String KEYSTORE_PASSWORD = "KEYSTORE_PASSWORD";
+
+    public CodeFlowAuthzState getCodeFlowPreferences()
+    {
+        String responseType = _preferences.get(CODE_FLOW_RESPONSE_TYPE_PREFERENCE_KEY, "code");
+        String clientId = _preferences.get(CODE_FLOW_CLIENT_ID_PREFERENCE_KEY, "");
+        String redirectUri = _preferences.get(CODE_FLOW_REDIRECT_URI_PREFERENCE_KEY, "se.curity.oauthtest://");
+        String scope = _preferences.get(CODE_FLOW_SCOPE_PREFERENCE_KEY, "");
+        String state = _preferences.get(CODE_FLOW_STATE_PREFERENCE_KEY, "");
+
+        return CodeFlowAuthzState.validState(responseType, clientId, redirectUri, scope, state);
+    }
+
+    public void putCodeFlowPreferences(CodeFlowAuthzState codeFlowAuthzState)
+    {
+        _preferences.put(CODE_FLOW_RESPONSE_TYPE_PREFERENCE_KEY, codeFlowAuthzState.getResponseType());
+        _preferences.put(CODE_FLOW_CLIENT_ID_PREFERENCE_KEY, codeFlowAuthzState.getClientId());
+        _preferences.put(CODE_FLOW_REDIRECT_URI_PREFERENCE_KEY, codeFlowAuthzState.getRedirectUri());
+        _preferences.put(CODE_FLOW_SCOPE_PREFERENCE_KEY, codeFlowAuthzState.getScope());
+        _preferences.put(CODE_FLOW_STATE_PREFERENCE_KEY, codeFlowAuthzState.getState());
+    }
 
     public OAuthServerState getOAuthServerPreferences()
     {
@@ -68,13 +95,13 @@ public final class UserPreferences
         return new GeneralState(verbose, maximumNotificationRows);
     }
 
-    public void putGeneralSettings(GeneralState generalState)
+    public void putGeneralPreferences(GeneralState generalState)
     {
         _preferences.putBoolean(VERBOSE, generalState.isVerbose());
         _preferences.putInt(MAX_NOTIFICATION_ROWS, generalState.getMaximumNotificationRows());
     }
 
-    public void putSslState(SslState sslState)
+    public void putSslPreferences(SslState sslState)
     {
         _preferences.put(SSL_OPTION, sslState.getSslOption().name());
         _preferences.put(TRUSTSTORE_FILE, sslState.getTrustStoreFile());


### PR DESCRIPTION
Little PR to save the preferences for doing the code flow. After this is merged, we won't have to continually enter in the `client_id`, `client_secret`, `redirect_uri`, `scope` and `state`.

OBS: This branch is based off of the other (fix/master/code-flow-redirect-uri-consideration) despite it's name.